### PR TITLE
Update knative-kafka-channel-controller ClusterRole

### DIFF
--- a/resources/knative-kafka/templates/rbac.yaml
+++ b/resources/knative-kafka/templates/rbac.yaml
@@ -34,6 +34,7 @@ rules:
   resources:
   - channels
   - channels/status
+  - subscriptions
   verbs:
   - get
   - list


### PR DESCRIPTION
Currently the kafka channel controller overwhelms itself in reading the Knative Subscriptions which belongs to messaging apigroups.
Unfortunately, the service account doesn't have the privilege to do so, due to missing Authorization. 

Hence, introducing this Change in Clusterrole