### PR TITLE
restrict kafka secret informer/lister to knative-eventing namespace

### DIFF
--- a/components/controller/pkg/client/injection/reconciler/knativekafka/v1alpha1/kafkasecret/controller.go
+++ b/components/controller/pkg/client/injection/reconciler/knativekafka/v1alpha1/kafkasecret/controller.go
@@ -2,6 +2,7 @@ package kafkasecret
 
 import (
 	"context"
+	"github.com/kyma-incubator/knative-kafka/components/controller/pkg/kafkasecretinformer"
 	"github.com/kyma-incubator/knative-kafka/components/controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -10,7 +11,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/client/injection/kube/client"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 )
@@ -32,7 +32,7 @@ var (
 // the provided Interface and optional Finalizer methods.
 func NewImpl(ctx context.Context, r Interface) *controller.Impl {
 	logger := logging.FromContext(ctx)
-	secretInformer := secret.Get(ctx)
+	kafkaSecretInformer := kafkasecretinformer.Get(ctx)
 
 	recorder := controller.GetEventRecorder(ctx)
 	if recorder == nil {
@@ -55,7 +55,7 @@ func NewImpl(ctx context.Context, r Interface) *controller.Impl {
 
 	rec := &reconcilerImpl{
 		Client:     kubeclient.Get(ctx).CoreV1(),
-		Lister:     secretInformer.Lister(),
+		Lister:     kafkaSecretInformer.Lister(),
 		Recorder:   recorder,
 		reconciler: r,
 	}

--- a/components/controller/pkg/controller/kafkachannel/controller.go
+++ b/components/controller/pkg/controller/kafkachannel/controller.go
@@ -9,13 +9,12 @@ import (
 	"github.com/kyma-incubator/knative-kafka/components/controller/pkg/client/injection/informers/knativekafka/v1alpha1/kafkachannel"
 	kafkachannelreconciler "github.com/kyma-incubator/knative-kafka/components/controller/pkg/client/injection/reconciler/knativekafka/v1alpha1/kafkachannel"
 	"github.com/kyma-incubator/knative-kafka/components/controller/pkg/env"
-	"github.com/kyma-incubator/knative-kafka/components/controller/pkg/util"
+	"github.com/kyma-incubator/knative-kafka/components/controller/pkg/kafkasecretinformer"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
-	"knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -35,7 +34,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	kafkachannelInformer := kafkachannel.Get(ctx)
 	deploymentInformer := deployment.Get(ctx)
 	serviceInformer := service.Get(ctx)
-	secretInformer := secret.Get(ctx)
+	kafkaSecretInformer := kafkasecretinformer.Get(ctx)
 
 	// Load The Environment Variables
 	environment, err := env.GetEnvironment(logger)
@@ -91,10 +90,9 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		FilterFunc: controller.Filter(kafkachannelv1alpha1.SchemeGroupVersion.WithKind(constants.KafkaChannelKind)),
 		Handler:    controller.HandleAll(controllerImpl.EnqueueLabelOfNamespaceScopedResource(constants.KafkaChannelNamespaceLabel, constants.KafkaChannelNameLabel)),
 	})
-	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: util.FilterKafkaSecrets(),
-		Handler:    controller.HandleAll(r.resetKafkaAdminClient(kafkaAdminClientType)),
-	})
+	kafkaSecretInformer.Informer().AddEventHandler(
+		controller.HandleAll(r.resetKafkaAdminClient(kafkaAdminClientType)),
+	)
 
 	// Return The KafkaChannel Controller Impl
 	return controllerImpl
@@ -102,7 +100,9 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 // Graceful Shutdown Hook
 func Shutdown() {
-	adminClient.Close()
+	if adminClient != nil {
+		adminClient.Close()
+	}
 }
 
 // Recreate The Kafka AdminClient On The Reconciler (Useful To Reload Cache Which Is Not Yet Exposed)

--- a/components/controller/pkg/kafkasecretinformer/kafkasecretinformer.go
+++ b/components/controller/pkg/kafkasecretinformer/kafkasecretinformer.go
@@ -1,0 +1,92 @@
+package kafkasecretinformer
+
+import (
+	"context"
+	"fmt"
+	commonconstants "github.com/kyma-incubator/knative-kafka/components/common/pkg/kafka/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	informerscorev1 "k8s.io/client-go/informers/core/v1"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/eventing/pkg/logging"
+	"knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/system"
+)
+
+//
+// Custom Kafka SecretInformer - Namespace & Label Restricted
+//
+// Note:  The default generated Knative Informers/Listers (e.g. SecretInformer) are all started against the same
+//        context/factory which is scoped as cluster-wide.  This means the Listers require RBAC permissions to
+//        access their resources in any namespace.  This is desirable for watching Services, Deployments, etc.,
+//        but is not desirable for watching Secrets for obvious reasons.  We're only interested in "Kafka"
+//        Secrets in the "System" namespace where knative-kafka is installed (i.e. knative-eventing).
+//        Therefore we've created the following custom "KafkaSecretInformer" which is based on a separate
+//        factory which is namespaced and tweaked to restrict focus to only "Kafka" Secrets.
+//
+
+// Add The InformerInjector Function With The Knative Injection Framework
+func init() {
+	injection.Default.RegisterInformer(withInformer)
+}
+
+// Key Used To Associate The Informer Inside The Context
+type Key struct{}
+
+// Custom InformerInjector For KafkaSecretInformer
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+
+	// Determine The "System" Namespace Where Knative-Kafka Is Running
+	namespace := system.Namespace()
+
+	// Define The SharedInformerOptions To Restrict To Specified Namespace & With KafkaSecret Label
+	sharedInformerOptions := []informers.SharedInformerOption{
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
+			listOptions.LabelSelector = fmt.Sprintf("%s=true", commonconstants.KafkaSecretLabel)
+		}),
+	}
+
+	// Create A SharedInformerFactory With The Namespaced / Labelled Options
+	namespacedSharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(client.Get(ctx), controller.DefaultResyncPeriod, sharedInformerOptions...)
+
+	// Create The Custom Kafka SecretInformer
+	kafkaSecretInformer := KafkaSecretInformer{
+		namespace: namespace,
+		factory:   namespacedSharedInformerFactory,
+	}
+
+	// Add To The Specified Context & Return The Informer
+	return context.WithValue(ctx, Key{}, kafkaSecretInformer), kafkaSecretInformer.Informer()
+}
+
+// Extract The Typed Kafka SecretInformer From The Specified Context
+func Get(ctx context.Context) informerscorev1.SecretInformer {
+	untyped := ctx.Value(Key{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panic("Unable to fetch kyma-incubator/knative-kafka/components/controller/pkg/kafkasecret/KafkaSecretInformer from context.")
+	}
+	return untyped.(informerscorev1.SecretInformer)
+}
+
+// Verify The KafkaSecretInformer Implements The K8S SecretInformer Interface
+var _ informerscorev1.SecretInformer = KafkaSecretInformer{}
+
+// Custom Kafka SecretInformer Implementation
+type KafkaSecretInformer struct {
+	namespace string
+	factory   informers.SharedInformerFactory
+}
+
+// Implement The K8S SecretInformer's Informer() Interface Function
+func (i KafkaSecretInformer) Informer() cache.SharedIndexInformer {
+	return i.factory.Core().V1().Secrets().Informer()
+}
+
+// Implement The K8S SecretInformer's Lister() Interface Function
+func (i KafkaSecretInformer) Lister() listerscorev1.SecretLister {
+	return listerscorev1.NewSecretLister(i.Informer().GetIndexer())
+}

--- a/components/controller/pkg/kafkasecretinformer/kafkasecretinformer_test.go
+++ b/components/controller/pkg/kafkasecretinformer/kafkasecretinformer_test.go
@@ -1,0 +1,35 @@
+package kafkasecretinformer
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes/fake"
+	"knative.dev/eventing/pkg/logging"
+	injectionclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/injection"
+	logtesting "knative.dev/pkg/logging/testing"
+	_ "knative.dev/pkg/system/testing"
+	"testing"
+)
+
+// Test The Get() Functionality
+func TestGet(t *testing.T) {
+
+	// Create A Context With Test Logger & K8S Client
+	ctx := logging.WithLogger(context.TODO(), logtesting.TestLogger(t).Desugar())
+	ctx = context.WithValue(ctx, injectionclient.Key{}, fake.NewSimpleClientset())
+
+	// Verify The KafkaSecretInformer Was Added To Knative Injection
+	informers := injection.Default.GetInformers()
+	assert.NotNil(t, informers)
+	assert.Len(t, informers, 1)
+
+	// Add The KafkaSecretInformer To The Test Context
+	ctx, controllerInformer := withInformer(ctx)
+	assert.NotNil(t, ctx)
+	assert.NotNil(t, controllerInformer)
+
+	// Perform The Test & Verify Results
+	kafkaSecretInformer := Get(ctx)
+	assert.NotNil(t, kafkaSecretInformer)
+}

--- a/components/controller/pkg/util/secret.go
+++ b/components/controller/pkg/util/secret.go
@@ -1,13 +1,11 @@
 package util
 
 import (
-	commonconstants "github.com/kyma-incubator/knative-kafka/components/common/pkg/kafka/constants"
 	"github.com/kyma-incubator/knative-kafka/components/controller/constants"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
 )
 
 // Get A Logger With Secret Info
@@ -33,24 +31,5 @@ func NewSecretOwnerReference(secret *corev1.Secret) metav1.OwnerReference {
 		UID:                secret.GetUID(),
 		BlockOwnerDeletion: &blockOwnerDeletion,
 		Controller:         &controller,
-	}
-}
-
-// Custom Filter For Selecting "Kafka" Secrets In knative-eventing Namespace
-func FilterKafkaSecrets() func(obj interface{}) bool {
-	return func(obj interface{}) bool {
-		if object, ok := obj.(metav1.Object); ok {
-			if object.GetNamespace() == constants.KnativeEventingNamespace {
-				labelFound := false
-				for label, value := range object.GetLabels() {
-					if label == commonconstants.KafkaSecretLabel && strings.ToLower(value) == "true" {
-						labelFound = true
-						break
-					}
-				}
-				return labelFound
-			}
-		}
-		return false
 	}
 }

--- a/components/controller/pkg/util/secret_test.go
+++ b/components/controller/pkg/util/secret_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	commonconstants "github.com/kyma-incubator/knative-kafka/components/common/pkg/kafka/constants"
 	"github.com/kyma-incubator/knative-kafka/components/controller/constants"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -47,46 +46,4 @@ func TestNewSecretOwnerReference(t *testing.T) {
 	assert.Equal(t, secret.ObjectMeta.Name, controllerRef.Name)
 	assert.True(t, *controllerRef.BlockOwnerDeletion)
 	assert.True(t, *controllerRef.Controller)
-}
-
-// Test The FilterKafkaSecrets() Functionality
-func TestFilterKafkaSecrets(t *testing.T) {
-	performFilterKafkaSecretsTest(t, constants.KnativeEventingNamespace, commonconstants.KafkaSecretLabel, "true", true)
-	performFilterKafkaSecretsTest(t, constants.KnativeEventingNamespace, commonconstants.KafkaSecretLabel, "TRUE", true)
-	performFilterKafkaSecretsTest(t, "InvalidNamespace", commonconstants.KafkaSecretLabel, "true", false)
-	performFilterKafkaSecretsTest(t, constants.KnativeEventingNamespace, "InvalidLabel", "true", false)
-	performFilterKafkaSecretsTest(t, constants.KnativeEventingNamespace, commonconstants.KafkaSecretLabel, "false", false)
-	performFilterKafkaSecretsTest(t, constants.KnativeEventingNamespace, commonconstants.KafkaSecretLabel, "InvalidValue", false)
-}
-
-// Perform A Single Instance Of The FilterKafkaSecrets() Test
-func performFilterKafkaSecretsTest(t *testing.T, namespace string, labelKey string, labelValue string, expectedFilterResult bool) {
-
-	// Test Data
-	const secretName = "TestSecretName"
-
-	// The Secret To Test
-	secret := corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       constants.SecretKind,
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"TestLabelA": "TestValueA",
-				labelKey:     labelValue,
-				"TestLabelB": "TestValueB",
-			},
-		},
-	}
-
-	// Get The Filter Function
-	result := FilterKafkaSecrets()
-	assert.NotNil(t, result)
-
-	// Test The Filter Function
-	actualFilterResult := result(secret.GetObjectMeta())
-	assert.Equal(t, expectedFilterResult, actualFilterResult)
 }

--- a/resources/knative-kafka/templates/rbac.yaml
+++ b/resources/knative-kafka/templates/rbac.yaml
@@ -116,6 +116,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 
 ---
 


### PR DESCRIPTION
Created a separate namespaced (and tweaked!) sharedinformerfactory for watching secrets and integrated it into the knative injection framework.

Expanded RBAC to allow patch of secrets (in knative-eventing only) in order to add finalizer.